### PR TITLE
Investigate GitHub Actions workflow issue

### DIFF
--- a/.github/workflows/schedule-tagger.yml
+++ b/.github/workflows/schedule-tagger.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   run-tagger:
     runs-on: ubuntu-latest
+    timeout-minutes: 10  # Prevent infinite hanging
 
     steps:
       - name: Checkout code
@@ -27,4 +28,4 @@ jobs:
           python main.py
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GMAIL_OAUTH_CLIENT_CONFIG: ${{ secrets.GMAIL_OAUTH_CLIENT_CONFIG }}
+          GMAIL_SERVICE_ACCOUNT_KEY: ${{ secrets.GMAIL_SERVICE_ACCOUNT_KEY }}

--- a/SERVICE_ACCOUNT_SETUP.md
+++ b/SERVICE_ACCOUNT_SETUP.md
@@ -1,0 +1,139 @@
+# Service Account Setup Guide
+
+This guide will help you set up service account authentication for your Gmail email classifier to work with GitHub Actions.
+
+## Prerequisites
+
+- Google Cloud Project with Gmail API enabled
+- GitHub repository with Actions enabled
+- Admin access to the Google Workspace (if using domain-wide delegation)
+
+## Step 1: Create a Service Account
+
+1. **Go to Google Cloud Console**
+   - Navigate to [Google Cloud Console](https://console.cloud.google.com/)
+   - Select your project (or create a new one)
+
+2. **Enable Gmail API**
+   - Go to "APIs & Services" > "Library"
+   - Search for "Gmail API"
+   - Click "Enable"
+
+3. **Create Service Account**
+   - Go to "IAM & Admin" > "Service Accounts"
+   - Click "Create Service Account"
+   - Enter a name (e.g., "gmail-email-classifier")
+   - Add description: "Service account for automated email classification"
+   - Click "Create and Continue"
+
+4. **Skip Role Assignment** (for now)
+   - Click "Continue" without adding roles
+   - Click "Done"
+
+## Step 2: Generate Service Account Key
+
+1. **Find your service account** in the list
+2. **Click on the email address** to open details
+3. **Go to "Keys" tab**
+4. **Click "Add Key" > "Create new key"**
+5. **Select "JSON" format**
+6. **Click "Create"**
+7. **Download and save the JSON file securely**
+
+## Step 3: Configure Domain-Wide Delegation (Required for Gmail Access)
+
+Since Gmail API requires accessing user data, you need to set up domain-wide delegation:
+
+1. **Enable Domain-Wide Delegation**
+   - In your service account details, check "Enable Google Workspace Domain-wide Delegation"
+   - Enter a product name (e.g., "Email Classifier")
+   - Click "Save"
+
+2. **Note the Client ID**
+   - Copy the "Client ID" from your service account details
+   - You'll need this for the next step
+
+3. **Configure in Google Workspace Admin Console**
+   - Go to [Google Admin Console](https://admin.google.com/)
+   - Navigate to "Security" > "Access and data control" > "API controls"
+   - Click "Manage Domain Wide Delegation"
+   - Click "Add new"
+   - Enter the Client ID from step 2
+   - Enter OAuth scopes: `https://www.googleapis.com/auth/gmail.modify`
+   - Click "Authorize"
+
+## Step 4: Update Code for Domain-Wide Delegation
+
+In your `main.py`, you need to specify which user's Gmail account to access. Uncomment and modify this line in the `gmail_authenticate()` function:
+
+```python
+# Replace 'user@yourdomain.com' with the actual email address
+credentials = credentials.with_subject('user@yourdomain.com')
+```
+
+## Step 5: Add GitHub Secrets
+
+1. **Go to your GitHub repository**
+2. **Navigate to Settings > Secrets and variables > Actions**
+3. **Add the following secrets:**
+
+   - **Name**: `GMAIL_SERVICE_ACCOUNT_KEY`
+   - **Value**: The entire contents of the JSON file you downloaded in Step 2
+   
+   - **Name**: `GEMINI_API_KEY` (if not already added)
+   - **Value**: Your Google Gemini API key
+
+## Step 6: Test the Setup
+
+1. **Trigger the workflow manually**
+   - Go to "Actions" tab in your GitHub repository
+   - Select your workflow
+   - Click "Run workflow"
+
+2. **Check the logs**
+   - Look for "Successfully authenticated with Gmail API using service account"
+   - Verify that emails are being processed
+
+## Troubleshooting
+
+### Common Issues:
+
+1. **"Service account does not have domain-wide delegation enabled"**
+   - Ensure you completed Step 3 correctly
+   - Verify the Client ID matches in both places
+
+2. **"Insufficient Permission" or "Access denied"**
+   - Check that domain-wide delegation is properly configured
+   - Verify the OAuth scopes are correct
+   - Ensure the subject email is valid
+
+3. **"Invalid service account key"**
+   - Verify the JSON key is copied completely to GitHub Secrets
+   - Check for any formatting issues or extra spaces
+
+4. **Authentication still failing**
+   - Double-check that Gmail API is enabled in your Google Cloud project
+   - Verify the service account email has the correct permissions
+
+### Debugging Tips:
+
+- Add logging to see what's happening:
+  ```python
+  print(f"Service account email: {service_account_info.get('client_email')}")
+  print(f"Project ID: {service_account_info.get('project_id')}")
+  ```
+
+- Test authentication locally first before deploying to GitHub Actions
+
+## Security Notes
+
+- **Never commit the service account key to your repository**
+- **Regularly rotate service account keys** (recommended every 90 days)
+- **Use the principle of least privilege** - only grant necessary permissions
+- **Monitor service account usage** in Google Cloud Console
+
+## Alternative: Personal Gmail Account
+
+If you're using a personal Gmail account (not Google Workspace), you'll need to use the refresh token approach instead. Service accounts with domain-wide delegation only work with Google Workspace domains.
+
+For personal accounts, refer to Option 2 in the `github_actions_fix_analysis.md` file.

--- a/github_actions_fix_analysis.md
+++ b/github_actions_fix_analysis.md
@@ -1,0 +1,192 @@
+# GitHub Actions Hanging Issue - Analysis & Solutions
+
+## Problem Identified
+
+The GitHub Actions workflow is getting stuck at this line in `main.py`:
+
+```python
+creds = flow.run_local_server(port=0, open_browser=False)
+```
+
+### Root Cause
+The `run_local_server()` method from Google's OAuth library is designed for **interactive authentication** where a user manually authorizes the application. In GitHub Actions (headless CI environment), this method:
+
+1. Starts a local HTTP server waiting for OAuth callbacks
+2. Hangs indefinitely since no user can complete the authorization flow
+3. Never receives the callback from Google's OAuth service
+4. Times out or runs until the GitHub Actions job limit (6 hours for free tier)
+
+## Solutions
+
+### Option 1: Service Account Authentication (Recommended)
+
+Service accounts are designed for server-to-server authentication without user interaction.
+
+#### Setup Steps:
+1. **Create a Service Account** in Google Cloud Console
+2. **Enable Gmail API** for the service account
+3. **Generate and download** the service account key (JSON file)
+4. **Store the JSON** as a GitHub Secret
+5. **Modify the authentication code** to use service accounts
+
+#### Code Changes:
+```python
+import json
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
+def gmail_authenticate():
+    """Authenticate using service account credentials."""
+    try:
+        # Load service account credentials from environment variable
+        service_account_info = json.loads(os.getenv("GMAIL_SERVICE_ACCOUNT_KEY"))
+        
+        credentials = service_account.Credentials.from_service_account_info(
+            service_account_info, 
+            scopes=SCOPES
+        )
+        
+        # For domain-wide delegation (if needed)
+        # credentials = credentials.with_subject('user@yourdomain.com')
+        
+        service = build("gmail", "v1", credentials=credentials)
+        return service
+        
+    except Exception as error:
+        print(f"Authentication failed: {error}")
+        return None
+```
+
+#### Requirements Update:
+```txt
+google-api-python-client
+google-auth
+google-genai
+```
+
+### Option 2: Pre-authorized Refresh Token
+
+Use a refresh token obtained from a previous interactive OAuth session.
+
+#### Setup Steps:
+1. **Run OAuth flow locally** once to get refresh token
+2. **Store refresh token** as GitHub Secret
+3. **Modify code** to use stored refresh token
+
+#### Code Changes:
+```python
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+
+def gmail_authenticate():
+    """Authenticate using stored refresh token."""
+    try:
+        client_config = json.loads(os.getenv("GMAIL_OAUTH_CLIENT_CONFIG"))
+        refresh_token = os.getenv("GMAIL_REFRESH_TOKEN")
+        
+        credentials = Credentials(
+            token=None,
+            refresh_token=refresh_token,
+            token_uri=client_config['installed']['token_uri'],
+            client_id=client_config['installed']['client_id'],
+            client_secret=client_config['installed']['client_secret'],
+            scopes=SCOPES
+        )
+        
+        # Refresh the token
+        credentials.refresh(Request())
+        
+        service = build("gmail", "v1", credentials=credentials)
+        return service
+        
+    except Exception as error:
+        print(f"Authentication failed: {error}")
+        return None
+```
+
+### Option 3: Application Default Credentials
+
+Use Google's Application Default Credentials (ADC) mechanism.
+
+#### Setup Steps:
+1. **Set up ADC** in the GitHub Actions environment
+2. **Configure credentials** through environment variables
+
+#### Code Changes:
+```python
+from google.auth import default
+
+def gmail_authenticate():
+    """Authenticate using Application Default Credentials."""
+    try:
+        credentials, project = default(scopes=SCOPES)
+        service = build("gmail", "v1", credentials=credentials)
+        return service
+        
+    except Exception as error:
+        print(f"Authentication failed: {error}")
+        return None
+```
+
+## Recommended Workflow Update
+
+Update the GitHub Actions workflow to handle the new authentication method:
+
+```yaml
+name: Run main.py on schedule
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-tagger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10  # Add timeout to prevent infinite hanging
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Run main.py
+        run: |
+          python main.py
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # Choose one based on selected solution:
+          GMAIL_SERVICE_ACCOUNT_KEY: ${{ secrets.GMAIL_SERVICE_ACCOUNT_KEY }}  # Option 1
+          # GMAIL_REFRESH_TOKEN: ${{ secrets.GMAIL_REFRESH_TOKEN }}            # Option 2
+          # GMAIL_OAUTH_CLIENT_CONFIG: ${{ secrets.GMAIL_OAUTH_CLIENT_CONFIG }}  # Option 2
+```
+
+## Additional Improvements
+
+1. **Add timeout**: Prevent jobs from running indefinitely
+2. **Add error handling**: Better error messages for debugging
+3. **Add logging**: Monitor authentication and API calls
+4. **Test locally**: Verify authentication works before deploying
+
+## Security Considerations
+
+- Never commit credentials to the repository
+- Use GitHub Secrets for all sensitive data
+- Regularly rotate service account keys
+- Follow principle of least privilege for API scopes
+
+## Next Steps
+
+1. Choose authentication method (Service Account recommended)
+2. Set up credentials in Google Cloud Console
+3. Update the code with new authentication method
+4. Add GitHub Secrets for credentials
+5. Test the workflow with `workflow_dispatch` trigger

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from typing import List, Dict
 
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-from google_auth_oauthlib.flow import InstalledAppFlow
+from google.oauth2 import service_account
 from google import genai
 from google.genai import types
 
@@ -32,38 +32,44 @@ except KeyError:
 
 def gmail_authenticate():
     """
-    Authenticates with the Gmail API using OAuth 2.0.
+    Authenticates with the Gmail API using service account credentials.
     
-    It uses a client secrets JSON configuration stored in an environment
-    variable to create an OAuth flow and get user credentials.
+    This method is designed for server-to-server authentication and works
+    well in automated environments like GitHub Actions.
     
     Returns:
         A Google API client service object for interacting with Gmail.
     """
-    creds = None
-    
-    # 1) Load the raw JSON OAuth client configuration from an environment variable.
     try:
-        clientconfig_str = os.getenv("GMAIL_OAUTH_CLIENT_CONFIG")
-        clientconfig = json.loads(clientconfig_str)
-    except KeyError:
-        print("Error: GMAIL_OAUTH_CLIENT_CONFIG environment variable not set.")
-        print("Please store your OAuth client JSON config in this variable.")
-        exit()
-    except json.JSONDecodeError:
-        print("Error: Could not decode the JSON in GMAIL_OAUTH_CLIENT_CONFIG.")
-        exit()
-
-    # 2) Spin up the authorization flow directly from the config dictionary.
-    flow = InstalledAppFlow.from_client_config(clientconfig, SCOPES)
-    creds = flow.run_local_server(port=0, open_browser=False)
-
-    # 3) Build and return the Gmail service object.
-    try:
-        service = build("gmail", "v1", credentials=creds)
+        # Load service account credentials from environment variable
+        service_account_key = os.getenv("GMAIL_SERVICE_ACCOUNT_KEY")
+        if not service_account_key:
+            print("Error: GMAIL_SERVICE_ACCOUNT_KEY environment variable not set.")
+            print("Please store your service account JSON key in this variable.")
+            return None
+            
+        service_account_info = json.loads(service_account_key)
+        
+        # Create credentials from service account info
+        credentials = service_account.Credentials.from_service_account_info(
+            service_account_info, 
+            scopes=SCOPES
+        )
+        
+        # For domain-wide delegation, uncomment and modify the following line:
+        # credentials = credentials.with_subject('user@yourdomain.com')
+        
+        # Build and return the Gmail service object
+        service = build("gmail", "v1", credentials=credentials)
+        print("Successfully authenticated with Gmail API using service account.")
         return service
-    except HttpError as error:
-        print(f"An error occurred while building the Gmail service: {error}")
+        
+    except json.JSONDecodeError:
+        print("Error: Could not decode the JSON in GMAIL_SERVICE_ACCOUNT_KEY.")
+        print("Please ensure the service account key is valid JSON.")
+        return None
+    except Exception as error:
+        print(f"Authentication failed: {error}")
         return None
 
 # ==============================================================================

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 google-api-python-client
-google-auth-httplib2
-google-auth-oauthlib
+google-auth
 google-genai


### PR DESCRIPTION
Implement service account authentication for Gmail API to resolve GitHub Actions workflow hanging.

The previous OAuth flow (`flow.run_local_server`) required user interaction, causing the workflow to hang indefinitely in a headless CI/CD environment. This PR switches to a server-to-server authentication method and includes a setup guide.